### PR TITLE
Annotations as axis and ChrX and Y on plot

### DIFF
--- a/R/get_bam_bed.R
+++ b/R/get_bam_bed.R
@@ -57,7 +57,8 @@ get_bam_bed <- function(bamdir, sampname, hgref = "hg19", resolution = 500) {
                     tilewidth = resolution * 1000, 
                     cut.last.tile.in.chrom = TRUE)
     ref <- bins[which(as.character(seqnames(bins)) %in% paste0("chr", 
-                                                        seq_len(22)))]
+                                                        c(seq_len(22), 
+                                                        "X", "Y")))]
     if (!any(grepl("chr", seqlevels(ref)))) {
         seqlevels(ref) <- paste(c(seq_len(22), "X", "Y"), sep = "")
         ref <- sort(ref)

--- a/R/plot_iCN.R
+++ b/R/plot_iCN.R
@@ -118,13 +118,14 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
     }
 
     chr.pos <- rep(NA, length(unique(seqnames(ref))))
-    for (chri in seq_len(22)) {
+    for (chri in seq_len(24)) {
         chr.pos[chri] <- length(ref[which(as.character(
-            seqnames(ref)) == paste0("chr", chri))])
+            seqnames(ref)) == paste0("chr", c(seq_len(22), 
+                                  "X", "Y"))[chri])])
     }
     chr.pos <- cumsum(chr.pos)
-    xpos <- round(c(0, chr.pos[seq_len(21)]) +
-        (chr.pos - c(0, chr.pos[seq_len(21)]))/2)
+    xpos <- round(c(0, chr.pos[seq_len(23)]) +
+        (chr.pos - c(0, chr.pos[seq_len(23)]))/2)
 
     # 1) iCN heatmap
     dat <- t(iCNmat)
@@ -161,8 +162,16 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
 
     # 4) chromosome
     anno.chrom <- NULL
-    for (i in seq_len(22)) {
-        if (i%%2 == 1) {
+    for (i in seq_len(24)) {
+        if (i == 23) {
+            temp <- matrix(rep(1, length(which(as.character(
+                seqnames(ref)) == "chrX"))), nrow = 1)
+            anno.chrom <- cbind(anno.chrom, temp)
+        } else if (i == 24) {
+            temp <- matrix(rep(2, length(which(as.character(
+                seqnames(ref)) == "chrY"))), nrow = 1)
+            anno.chrom <- cbind(anno.chrom, temp)
+        } else if (i%%2 == 1) {
             temp <- matrix(rep(1, length(which(as.character(
                 seqnames(ref)) == paste0("chr", i)))), nrow = 1)
             anno.chrom <- cbind(anno.chrom, temp)
@@ -175,7 +184,7 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
     image(t(anno.chrom), col = c("gray", "black"),
         xaxs = "i", yaxs = "i", axes = FALSE)
     pos.text <- xpos/length(ref)
-    text(pos.text, 0.2, seq(22), col = c("black", "grey"), cex = 1.5)
+    text(pos.text, 0.2, c(seq(22), "X", "Y"), col = c("black", "grey"), cex = 1.2)
 
     # 5) Gini legend
     par(mar = c(2, 2, 2, 4))

--- a/R/plot_iCN.R
+++ b/R/plot_iCN.R
@@ -88,22 +88,22 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
         }
     } else {
         if (plot.dendrogram) {
-            mm <- matrix(c(0, 0, 0, 5, 0,
-                2, 3, 4, 1, 6,
-                2, 3, 4, 1, 7,
-                2, 3, 4, 1, 8), nrow = 4, byrow = TRUE)
+            mm <- matrix(c(0, 0, 4, 7, 0,
+                2, 3, 1, 7, 5,
+                2, 3, 1, 7, 0,
+                2, 3, 1, 7, 6), nrow = 4, byrow = TRUE)
             mh <- c(2, 20, 20, 20)
             mh <- mh/sum(mh)
-            mw <- c(0.25, 0.1, 0.1, 5, 0.5)
+            mw <- c(0.25, 0.1, 5, 0.2, 0.5)
             mw <- mw/sum(mw)
         } else {
-            mm <- matrix(c(0, 0, 0, 4, 0,
-                0, 2, 3, 1, 5,
-                0, 2, 3, 1, 6,
-                0, 2, 3, 1, 7), nrow = 4, byrow = TRUE)
+            mm <- matrix(c(0, 0, 3, 6, 0,
+                0, 2, 1, 6, 4,
+                0, 2, 1, 6, 0,
+                0, 2, 1, 6, 5), nrow = 4, byrow = TRUE)
             mh <- c(2, 20, 20, 20)
             mh <- mh/sum(mh)
-            mw <- c(0.25, 0.1, 0.1, 5, 0.5)
+            mw <- c(0.25, 0.1, 5, 0.2, 0.5)
             mw <- mw/sum(mw)
         }
     }
@@ -140,6 +140,11 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
     for (i in seq_len(length(chr.pos))) {
         abline(v = chr.pos[i]/length(ref), lwd = 2)
     }
+    if (!is.null(annotation)) {
+        anno.level <- levels(annotation)
+        anno.mat <- matrix(match(annotation[rclust$order], anno.level), nrow = nrow(dat), ncol = 1)
+        axis(side = 4, at = seq(1,0,length.out=length(anno.level)), labels = anno.level[anno.mat], las = 2)
+    }
 
     # 2) hclust
     if (plot.dendrogram) {
@@ -154,18 +159,7 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
     smart_image(anno.Gini, col = col.Gini, xaxs = "i",
         yaxs = "i", axes = FALSE)
 
-    if (!is.null(annotation)) {
-        # 4) Customized annotation
-        anno.level <- levels(annotation)
-        anno.mat <- matrix(match(annotation[rclust$order], anno.level),
-            nrow = nrow(dat), ncol = 1)
-        col.anno <- brewer.pal(n = 12, name = "Set3")[
-            sort(unique(match(annotation[rclust$order], anno.level)))]
-        smart_image(anno.mat, col = col.anno, xaxs = "i",
-            yaxs = "i", axes = FALSE)
-    }
-
-    # 5) chromosome
+    # 4) chromosome
     anno.chrom <- NULL
     for (i in seq_len(22)) {
         if (i%%2 == 1) {
@@ -183,7 +177,7 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
     pos.text <- xpos/length(ref)
     text(pos.text, 0.2, seq(22), col = c("black", "grey"), cex = 1.5)
 
-    # 6) Gini legend
+    # 5) Gini legend
     par(mar = c(2, 2, 2, 4))
     image(1, seq_len(length(brewer.pal(n = 8, name = "Blues"))),
         t(as.matrix(seq_len(length(brewer.pal(n = 8, name = "Blues"))))),
@@ -194,13 +188,7 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
         col = NA, lwd.ticks = 0, cex.axis = 1.5, las = 2, font = 2)
     title("Gini", cex.main = 1.5)
 
-    if (!is.null(annotation)) {
-        plot(0, 0, type = "n", axes = FALSE)
-        legend("center", legend = sort(unique(annotation)),
-            col = col.anno, pch = 15, bty = "n", cex = 1.5)
-    }
-
-    # 8) iCN legend
+    # 6) iCN legend
     par(mar = c(2, 2, 2, 4))
     image(1, seq_len(length(hm_col[iCNtab + 1])),
         t(as.matrix(seq_len(length(hm_col[iCNtab + 1])))),
@@ -210,6 +198,8 @@ plot_iCN <- function(iCNmat, ref, Gini, annotation = NULL,
         labels = c(0:7)[iCNtab + 1], col.ticks = "white", col = NA,
         lwd.ticks = 0, cex.axis = 1.5, las = 2, font = 2)
     title("integer CN", cex.main = 1.5)
+
+    # 7) Buffer space for annotations right-side axis
     dev.off()
 }
 


### PR DESCRIPTION
Hello SCOPE contributors, these are two improvements you may find useful if you choose to incorporate them. Feel free to edit as you see fit!

- Commit 1 - Annotations to the CNV plot are now a secondary y-axis on the right side of the plot
  - Column 7 in the `mm` matrix in `plot_iCN()` becomes an empty space so the legends do not cover the annotations. These annotations are ordered correctly to correspond with the hierarchical clustering
  - Annotations are no longer part of the legend
- Commit 2 - chrX and chrY added to the CNV plot
  - Line 59 of `get_bam_bed()` now obtains chrX and chrY data
  - `plot_iCN()` originally could only process 22 chromosomes but now can do all 24

See this image as an example of both Commits (although my data did not have any chrY)
![test2](https://user-images.githubusercontent.com/25641867/77703344-cf6c6400-6f77-11ea-8303-9176ad192fa7.png)
